### PR TITLE
Update doctrine.dbal.path in config.yml

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -79,7 +79,7 @@ doctrine:
         # stores options that change from one server to another
         driver: "pdo_sqlite"
         # temp workaround for https://github.com/doctrine/dbal/issues/1106: define DB path here
-        path: "%kernel.root_dir%/../var/data/blog.sqlite"
+        path: "%kernel.root_dir%/data/blog.sqlite"
 
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"


### PR DESCRIPTION
Symfony demo doesn't seem to work out of the box when using the `prod` configuration because the path used by the `prod` and the `dev` configurations are not the same.

    %kernel.root_dir%/../var/data/blog.sqlite

vs

    %kernel.root_dir%/data/blog.sqlite

Even if it would be better to separate the both two databases in the real life, here is the patch I use to make it work the same way on a local `dev` mode and on a remote shared hosting.